### PR TITLE
Fix deprecation for Extension

### DIFF
--- a/src/DependencyInjection/MeilisearchExtension.php
+++ b/src/DependencyInjection/MeilisearchExtension.php
@@ -7,9 +7,9 @@ namespace Meilisearch\Bundle\DependencyInjection;
 use Meilisearch\Bundle\MeilisearchBundle;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 final class MeilisearchExtension extends Extension
 {


### PR DESCRIPTION
`The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Meilisearch\Bundle\DependencyInjection\MeilisearchExtension".`