### PR TITLE
feat: use composer's `--no-security-blocking` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,5 +79,3 @@ If you want to know more about the development workflow or want to contribute, p
 <hr>
 
 **Meilisearch** provides and maintains many **SDKs and Integration tools** like this one. We want to provide everyone with an **amazing search experience for any kind of project**. If you want to contribute, make suggestions, or just know what's going on right now, visit us in the [integration-guides](https://github.com/meilisearch/integration-guides) repository.
-
-check ci


### PR DESCRIPTION
check ci for lowest run

With the new composer version the runs for older minor symfony version like 7.1 fail

Solutions
- use older composer version
- configure composer to allow unsecured versions
- drop tests for symfony 7.0, 7.1, 7.2 tests
- ?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a short line to the README for CI/reference.

* **Chores**
  * Updated CI workflow configuration for dependency installation options to alter installation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->