### PR TITLE
Wrap search response in SearchResults object with array access/iterator

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -22,8 +22,7 @@ return (new PhpCsFixer\Config())
             'import_constants' => false,
         ],
         'no_superfluous_phpdoc_tags' => false,
-        // @todo: when we'll support only PHP 8.0 and upper, we can enable `parameters` for `trailing_comma_in_multiline` rule
-        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays', 'match'/* , 'parameters' */]],
-        // @todo: when we'll support only PHP 8.0 and upper, we can enable this
-        'get_class_to_class_keyword' => false,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays', 'match', 'parameters']],
+        'get_class_to_class_keyword' => true,
+        'phpdoc_to_comment' => ['ignored_tags' => ['var']], // changes phpdoc and breaks SCA
     ]);

--- a/src/DataProvider/OrmEntityProvider.php
+++ b/src/DataProvider/OrmEntityProvider.php
@@ -71,9 +71,9 @@ final class OrmEntityProvider implements DataProviderInterface
 
     public function getIdentifierValues(object $object): array
     {
-        $manager = $this->managerRegistry->getManagerForClass(\get_class($object));
+        $manager = $this->managerRegistry->getManagerForClass($object::class);
 
-        return $manager->getClassMetadata(\get_class($object))->getIdentifierValues($object);
+        return $manager->getClassMetadata($object::class)->getIdentifierValues($object);
     }
 
     public function normalizeIdentifiers(array $identifiers): string|int

--- a/src/Model/SearchResults.php
+++ b/src/Model/SearchResults.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Bundle\Model;
+
+/**
+ * @template T of object
+ */
+final class SearchResults implements \ArrayAccess, \Countable, \IteratorAggregate, \JsonSerializable
+{
+    /**
+     * @var array<T>
+     */
+    private readonly array $hits;
+    private readonly int $hitsCount;
+    private readonly string $query;
+    private readonly int $processingTimeMs;
+
+    private readonly ?int $limit;
+    private readonly ?int $offset;
+    private readonly ?int $estimatedTotalHits;
+    private readonly ?int $nbHits;
+
+    private readonly ?int $page;
+    private readonly ?int $hitsPerPage;
+    private readonly ?int $totalHits;
+    private readonly ?int $totalPages;
+
+    private readonly int $semanticHitCount;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private readonly array $facetDistribution;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private readonly array $facetStats;
+
+    private readonly ?string $requestUid;
+
+    private readonly array $raw;
+
+    /**
+     * @param array<T>             $hits
+     * @param array<string, mixed> $facetDistribution
+     * @param array<string, mixed> $facetStats
+     */
+    public function __construct(
+        array $hits,
+        string $query,
+        int $processingTimeMs,
+
+        ?int $limit = null,
+        ?int $offset = null,
+        ?int $estimatedTotalHits = null,
+        ?int $nbHits = null,
+
+        ?int $page = null,
+        ?int $hitsPerPage = null,
+        ?int $totalHits = null,
+        ?int $totalPages = null,
+
+        int $semanticHitCount = 0,
+
+        array $facetDistribution = [],
+        array $facetStats = [],
+
+        ?string $requestUid = null,
+
+        array $raw = [],
+    ) {
+        $this->hits = $hits;
+        $this->hitsCount = \count($hits);
+        $this->query = $query;
+        $this->processingTimeMs = $processingTimeMs;
+
+        $this->limit = $limit;
+        $this->offset = $offset;
+        $this->estimatedTotalHits = $estimatedTotalHits;
+        $this->nbHits = $nbHits;
+
+        $this->page = $page;
+        $this->hitsPerPage = $hitsPerPage;
+        $this->totalHits = $totalHits;
+        $this->totalPages = $totalPages;
+
+        $this->semanticHitCount = $semanticHitCount;
+
+        $this->facetDistribution = $facetDistribution;
+        $this->facetStats = $facetStats;
+
+        $this->requestUid = $requestUid;
+
+        $this->raw = $raw;
+    }
+
+    /**
+     * @return array<T>
+     */
+    public function getHits(): array
+    {
+        return $this->hits;
+    }
+
+    public function getHitsCount(): int
+    {
+        return $this->hitsCount;
+    }
+
+    public function getQuery(): string
+    {
+        return $this->query;
+    }
+
+    public function getProcessingTimeMs(): int
+    {
+        return $this->processingTimeMs;
+    }
+
+    public function getLimit(): ?int
+    {
+        return $this->limit;
+    }
+
+    public function getOffset(): ?int
+    {
+        return $this->offset;
+    }
+
+    public function getEstimatedTotalHits(): ?int
+    {
+        return $this->estimatedTotalHits;
+    }
+
+    public function getNbHits(): ?int
+    {
+        return $this->nbHits;
+    }
+
+    public function getPage(): ?int
+    {
+        return $this->page;
+    }
+
+    public function getHitsPerPage(): ?int
+    {
+        return $this->hitsPerPage;
+    }
+
+    public function getTotalHits(): ?int
+    {
+        return $this->totalHits;
+    }
+
+    public function getTotalPages(): ?int
+    {
+        return $this->totalPages;
+    }
+
+    public function getSemanticHitCount(): int
+    {
+        return $this->semanticHitCount;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getFacetDistribution(): array
+    {
+        return $this->facetDistribution;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getFacetStats(): array
+    {
+        return $this->facetStats;
+    }
+
+    public function getRequestUid(): ?string
+    {
+        return $this->requestUid;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getRaw(): array
+    {
+        return $this->raw;
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->hits[$offset]);
+    }
+
+    /**
+     * @return T
+     */
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->hits[$offset];
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException('Cannot modify hits');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException('Cannot modify hits');
+    }
+
+    public function count(): int
+    {
+        return \count($this->hits);
+    }
+
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->hits);
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'hits' => $this->hits,
+            'query' => $this->query,
+            'processingTimeMs' => $this->processingTimeMs,
+            'limit' => $this->limit,
+            'offset' => $this->offset,
+            'estimatedTotalHits' => $this->estimatedTotalHits,
+            'nbHits' => $this->nbHits,
+            'page' => $this->page,
+            'hitsPerPage' => $this->hitsPerPage,
+            'totalHits' => $this->totalHits,
+            'totalPages' => $this->totalPages,
+            'semanticHitCount' => $this->semanticHitCount,
+            'facetDistribution' => $this->facetDistribution,
+            'facetStats' => $this->facetStats,
+            'requestUid' => $this->requestUid,
+        ];
+    }
+}

--- a/src/SearchManagerInterface.php
+++ b/src/SearchManagerInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Meilisearch\Bundle;
 
 use Meilisearch\Bundle\Exception\NotSearchableException;
+use Meilisearch\Bundle\Model\SearchResults;
 
 /**
  * @phpstan-import-type IndexDeletionTask from Engine
@@ -81,11 +82,11 @@ interface SearchManagerInterface
      * @param class-string<T> $className
      * @param array<mixed>    $searchParams
      *
-     * @return list<T>
+     * @return SearchResults<T>
      *
      * @throws NotSearchableException
      */
-    public function search(string $className, string $query = '', array $searchParams = []): array;
+    public function search(string $className, string $query = '', array $searchParams = []): SearchResults;
 
     /**
      * @param class-string $className

--- a/src/SearchService.php
+++ b/src/SearchService.php
@@ -60,7 +60,7 @@ interface SearchService
         ObjectManager $objectManager,
         string $className,
         string $query = '',
-        array $searchParams = []
+        array $searchParams = [],
     ): array;
 
     /**
@@ -73,7 +73,7 @@ interface SearchService
     public function rawSearch(
         string $className,
         string $query = '',
-        array $searchParams = []
+        array $searchParams = [],
     ): array;
 
     /**

--- a/src/SearchableEntity.php
+++ b/src/SearchableEntity.php
@@ -44,7 +44,7 @@ final class SearchableEntity
         $entity,
         ClassMetadata $entityMetadata,
         ?NormalizerInterface $normalizer = null,
-        array $extra = []
+        array $extra = [],
     ) {
         $this->indexUid = $indexUid;
         $this->entity = $entity;

--- a/src/SearchableObject.php
+++ b/src/SearchableObject.php
@@ -31,7 +31,7 @@ final class SearchableObject
         private readonly object $object,
         private readonly \Stringable|string|int $identifier,
         private readonly NormalizerInterface $normalizer,
-        array $normalizationContext = []
+        array $normalizationContext = [],
     ) {
         $this->normalizationContext = array_merge($normalizationContext, ['meilisearch' => true]);
     }

--- a/src/Services/MeilisearchService.php
+++ b/src/Services/MeilisearchService.php
@@ -210,12 +210,12 @@ final class MeilisearchService implements SearchService
         ObjectManager $objectManager,
         string $className,
         string $query = '',
-        array $searchParams = []
+        array $searchParams = [],
     ): array {
         trigger_deprecation('meilisearch/meilisearch-symfony', '0.16', 'Passing `Doctrine\Persistence\ObjectManager` to search() is deprecated. Use `Meilisearch\Bundle\Services\MeilisearchManager::search()` instead.');
 
         if (null !== $this->manager) {
-            return $this->manager->search($className, $query, $searchParams);
+            return $this->manager->search($className, $query, $searchParams)->jsonSerialize();
         }
 
         $this->assertIsSearchable($className);
@@ -256,7 +256,7 @@ final class MeilisearchService implements SearchService
     public function rawSearch(
         string $className,
         string $query = '',
-        array $searchParams = []
+        array $searchParams = [],
     ): array {
         trigger_deprecation('meilisearch/meilisearch-symfony', '0.16', 'Using `Meilisearch\Bundle\Services\MeilisearchService::rawSearch()` is deprecated. Use `Meilisearch\Bundle\Services\MeilisearchManager::rawSearch()` instead.');
 
@@ -408,7 +408,7 @@ final class MeilisearchService implements SearchService
     private function makeSearchServiceResponseFrom(
         ObjectManager $objectManager,
         array $entities,
-        callable $operation
+        callable $operation,
     ): array {
         $batch = [];
         foreach (array_chunk($entities, $this->configuration->get('batchSize')) as $chunk) {
@@ -455,7 +455,7 @@ final class MeilisearchService implements SearchService
         $resolver ??= (function () {
             // Native lazy objects compatibility
             if (PHP_VERSION_ID >= 80400 && class_exists(LegacyReflectionFields::class)) {
-                return fn (object $object) => \get_class($object);
+                return fn (object $object) => $object::class;
             }
 
             // Doctrine ORM v3+ compatibility

--- a/tests/Entity/Actor.php
+++ b/tests/Entity/Actor.php
@@ -8,7 +8,7 @@ final class Actor
 {
     public function __construct(
         public readonly int $id,
-        public readonly string $name
+        public readonly string $name,
     ) {
     }
 }

--- a/tests/Entity/Movie.php
+++ b/tests/Entity/Movie.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Bundle\Tests\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'movies')]
+class Movie
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING)]
+    private string $title;
+
+    #[ORM\Column(type: Types::STRING, nullable: true)]
+    private ?string $genre = null;
+
+    public function __construct(string $title, ?string $genre = null)
+    {
+        $this->title = $title;
+        $this->genre = $genre;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getGenre(): ?string
+    {
+        return $this->genre;
+    }
+}

--- a/tests/Integration/Command/MeilisearchClearCommandTest.php
+++ b/tests/Integration/Command/MeilisearchClearCommandTest.php
@@ -38,6 +38,7 @@ Cleared sf_phpunit__dummy_custom_groups index of Meilisearch\Bundle\Tests\Entity
 Cleared sf_phpunit__dynamic_settings index of Meilisearch\Bundle\Tests\Entity\DynamicSettings
 Cleared sf_phpunit__actor index of Meilisearch\Bundle\Tests\Entity\Actor
 Cleared sf_phpunit__cars index of Meilisearch\Bundle\Tests\Entity\Car
+Cleared sf_phpunit__movies index of Meilisearch\Bundle\Tests\Entity\Movie
 Done!
 
 EOD, $commandTester->getDisplay());

--- a/tests/Integration/Command/MeilisearchCreateCommandTest.php
+++ b/tests/Integration/Command/MeilisearchCreateCommandTest.php
@@ -27,7 +27,7 @@ final class MeilisearchCreateCommandTest extends BaseKernelTestCase
         $createCommandTester = new CommandTester($createCommand);
         $createCommandTester->execute([]);
 
-        $this->assertSame($this->client->getTasks()->getResults()[0]['type'], 'indexCreation');
+        $this->assertSame('indexCreation', $this->client->getTasks()->getResults()[0]['type']);
     }
 
     #[TestWith([false])]
@@ -61,6 +61,8 @@ Setting "stopWords" updated of "sf_phpunit__dynamic_settings".
 Setting "synonyms" updated of "sf_phpunit__dynamic_settings".
 Creating index sf_phpunit__actor for Meilisearch\Bundle\Tests\Entity\Actor
 Creating index sf_phpunit__cars for Meilisearch\Bundle\Tests\Entity\Car
+Creating index sf_phpunit__movies for Meilisearch\Bundle\Tests\Entity\Movie
+Setting "filterableAttributes" updated of "sf_phpunit__movies".
 Creating index sf_phpunit__aggregated for Meilisearch\Bundle\Tests\Entity\Post
 Creating index sf_phpunit__aggregated for Meilisearch\Bundle\Tests\Entity\Tag
 Done!
@@ -79,6 +81,7 @@ Creating index sf_phpunit__dummy_custom_groups for Meilisearch\Bundle\Tests\Enti
 Creating index sf_phpunit__dynamic_settings for Meilisearch\Bundle\Tests\Entity\DynamicSettings
 Creating index sf_phpunit__actor for Meilisearch\Bundle\Tests\Entity\Actor
 Creating index sf_phpunit__cars for Meilisearch\Bundle\Tests\Entity\Car
+Creating index sf_phpunit__movies for Meilisearch\Bundle\Tests\Entity\Movie
 Creating index sf_phpunit__aggregated for Meilisearch\Bundle\Tests\Entity\Post
 Creating index sf_phpunit__aggregated for Meilisearch\Bundle\Tests\Entity\Tag
 Done!

--- a/tests/Integration/Command/MeilisearchDeleteCommandTest.php
+++ b/tests/Integration/Command/MeilisearchDeleteCommandTest.php
@@ -39,6 +39,7 @@ Deleted sf_phpunit__dummy_custom_groups
 Deleted sf_phpunit__dynamic_settings
 Deleted sf_phpunit__actor
 Deleted sf_phpunit__cars
+Deleted sf_phpunit__movies
 Done!
 
 EOD, $clearOutput);

--- a/tests/Integration/Command/MeilisearchUpdateSettingsCommandTest.php
+++ b/tests/Integration/Command/MeilisearchUpdateSettingsCommandTest.php
@@ -43,6 +43,7 @@ Setting "filterableAttributes" updated of "sf_phpunit__dynamic_settings".
 Setting "searchableAttributes" updated of "sf_phpunit__dynamic_settings".
 Setting "stopWords" updated of "sf_phpunit__dynamic_settings".
 Setting "synonyms" updated of "sf_phpunit__dynamic_settings".
+Setting "filterableAttributes" updated of "sf_phpunit__movies".
 Done!
 
 EOD, $importOutput);

--- a/tests/config/meilisearch.yaml
+++ b/tests/config/meilisearch.yaml
@@ -60,6 +60,10 @@ meilisearch:
       data_provider: Meilisearch\Bundle\Tests\Integration\Fixtures\ActorDataProvider
     - name: cars
       class: 'Meilisearch\Bundle\Tests\Entity\Car'
+    - name: movies
+      class: 'Meilisearch\Bundle\Tests\Entity\Movie'
+      settings:
+        filterableAttributes: ['genre']
 
 services:
   Meilisearch\Bundle\Tests\Integration\Fixtures\:


### PR DESCRIPTION
# Pull Request

I hope that I understood correctly what @jeremy-ritec is asking in #353.
Not flagging this as a BC break because `MeilisearchManager` was not released yet.

## Related issue
Fixes #353
Fixes #421

## What does this PR do?
- Returns `SearchResults` from the new `MeilisearchManager` instead of plain array
- Updates CS rules to use PHP ^8.0 features
- Improves `waitForAllTasks` to exclude already completed or failed ones

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search results now return a structured `SearchResults` object with comprehensive metadata including hits, pagination details, processing time, and facet distribution data.
  * Added support for faceted search filtering, enabling fine-grained result categorization.

* **Refactor**
  * Improved code consistency with trailing comma formatting in parameter lists.
  * Enhanced PHP 8+ compatibility in class resolution logic.

* **Chores**
  * Updated code style rules and formatting standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->